### PR TITLE
Add string evaluator

### DIFF
--- a/code/evaluators.go
+++ b/code/evaluators.go
@@ -29,6 +29,7 @@ var evaluators = map[TokenType]evaluator{
 	Vector:            evaluateVector,
 	Name:              evaluateName,
 	NameTableEntry:    basicString(""),
+	String:            evaluateString,
 }
 
 func evaluateStartOfExpression(state *stateHolder) string {
@@ -80,6 +81,11 @@ func evaluatePair(state *stateHolder) string {
 func evaluateName(state *stateHolder) string {
 	checksum := hex.EncodeToString(state.token.Chunk[1:])
 	return state.names.Get(checksum)
+}
+
+func evaluateString(state *stateHolder) string {
+	chunk := state.token.Chunk
+	return "\"" + string(chunk[5:len(chunk)-1]) + "\""
 }
 
 func basicString(s string) evaluator {

--- a/test/syntax_test.go
+++ b/test/syntax_test.go
@@ -69,6 +69,13 @@ func TestSyntax(t *testing.T) {
 			"TurboTime",
 		},
 
+		// Strings -------------------------------------------------------
+		{[]Token{{String, []byte{
+			any, 0x0D, 0x00, 0x00, 0x00, 0x4A, 0x6F,
+			0x79, 0x20, 0x44, 0x69, 0x76, 0x69, 0x73,
+			0x69, 0x6F, 0x6E, 0x00}}},
+			"\"Joy Division\""},
+
 		// Addition  ------------------------------------------------------
 		{[]Token{
 			{Integer, []byte{any, 0x09, 0x00, 0x00, 0x00}},


### PR DESCRIPTION
This adds string evaluation.

`0x1B 0x0A 0x00 0x00 0x00 0x54 0x52 0x49 0x43 0x4B 0x42 0x41 0x49 0x4C 0x00`
TRICKBAIL

`0x0A` indicates the string length including the null termination byte.
So it's integer(4 bytes) for the length..

I didn't include this in the generated syntax, although we could do something like `%s(10, TRICKBAIL)`

But i'd prefer if this is done on the compiling step where we can recalculate the size and store the length back in the qb format. It's unnecessary for reading imo.